### PR TITLE
Feat/workflow chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Add `Task.unique_name` property which adds on the non-trivial `Task.context` to `Task.name`.
 - Tasks can be accessed from the task list via dot-notation. Fix [#90](https://github.com/LightForm-group/matflow/issues/90).
 - Add `Task.elements_idx` property to retrieve to correct `elements_idx` dict for that task.
+- Add new exception type: `ParameterImportError`.
+- Add ability to import parameters from existing workflows. Fix [#30](https://github.com/LightForm-group/matflow/issues/30)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changed
 
 - Non-trivial task contexts are now part of the task directory name to help distinguish task directories where multiple contexts are used. Fix [#50](https://github.com/LightForm-group/matflow/issues/50).
+- Add `context` argument to `Workflow.get_input_tasks` and `Workflow.get_output_tasks`.
 
 ## [0.2.17] - 2021.02.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Allow embedding file-path inputs (inputs that are text files) into the HDF5 file. Fix [#86](https://github.com/LightForm-group/matflow/issues/86).
 - Add `Task.unique_name` property which adds on the non-trivial `Task.context` to `Task.name`.
 - Tasks can be accessed from the task list via dot-notation. Fix [#90](https://github.com/LightForm-group/matflow/issues/90).
+- Add `Task.elements_idx` property to retrieve to correct `elements_idx` dict for that task.
 
 ### Changed
 

--- a/matflow/errors.py
+++ b/matflow/errors.py
@@ -85,3 +85,7 @@ class CommandError(Exception):
 
 class WorkflowIterationError(Exception):
     """For issues with resolving requested iterations."""
+
+
+class ParameterImportError(Exception):
+    """For issues with importing parameters from pre-existing workflows."""

--- a/matflow/models/construction.py
+++ b/matflow/models/construction.py
@@ -1526,12 +1526,14 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate, imported_paramet
 
                     iter_current_task = [task_dep] * elems_per_iter
                     iter_current_loc = [None] * elems_per_iter
+                    iter_import_key = [None] * elems_per_iter
 
                     add_elements = {
                         'local_input_idx': iter_current_loc,
                         'task_idx': iter_current_task,
                         'element_idx': iter_current_elems_idx,
                         'group': iter_current_group,
+                        'import_key': iter_import_key,
                     }
                     # print(f'\t\t\tAdditional elements are: {add_elements}')
 
@@ -1569,12 +1571,14 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate, imported_paramet
                         iter_current_group = [inputs_idx['group'][0]] * elems_per_iter
                         iter_current_task = [inputs_idx['task_idx'][0]] * elems_per_iter
                         iter_current_loc = [None] * elems_per_iter
+                        iter_import_key = [inputs_idx['import_key'][0]] * elems_per_iter
 
                         add_elements = {
                             'local_input_idx': iter_current_loc,
                             'task_idx': iter_current_task,
                             'element_idx': iter_current_elems_idx,
                             'group': iter_current_group,
+                            'import_key': iter_import_key,
                         }
 
                         # print(f'\t\t\tFound non-local inputs: additional elements '

--- a/matflow/models/construction.py
+++ b/matflow/models/construction.py
@@ -343,7 +343,7 @@ def get_software_instance(software, run_options, all_software, type_label=''):
     return match
 
 
-def get_input_dependency(task_info_lst, input_dict, input_task_idx):
+def get_input_dependency(task_info_lst, input_dict, input_task_idx, imported_parameters):
 
     param_name = input_dict['name']
     param_context = input_dict['context']
@@ -353,6 +353,24 @@ def get_input_dependency(task_info_lst, input_dict, input_task_idx):
 
     input_dependency = []
 
+    # First check imported parameters:
+    for (imp_param_name, imp_param_context) in imported_parameters.keys():
+        if (
+            param_context == imp_param_context or (
+                (imp_param_context == downstream_task_context) and (param_context is None)
+            ) or (
+                imp_param_context == DEFAULT_TASK_CONTEXT
+            )
+        ):
+            if param_name == imp_param_name:
+                input_dependency.append({
+                    'from_task': None,
+                    'from_import': (imp_param_name, imp_param_context),
+                    'dependency_type': 'output',
+                    'is_parameter_modifying_task': False,
+                })
+
+    # Now check other tasks:
     for task_idx, task_info in enumerate(task_info_lst):
 
         if task_idx == input_task_idx:
@@ -371,13 +389,14 @@ def get_input_dependency(task_info_lst, input_dict, input_task_idx):
             )
         ):
             # A dependency may exist! The parameter as an output in an upstream task takes
-            #  precedence over the parameter as an input in that same task:
+            # precedence over the parameter as an input in that same task:
             if (
                 param_name in task_info['schema'].outputs and
                 task_info['name'] not in input_dict['ignore_dependency_from']
             ):
                 input_dependency.append({
                     'from_task': task_idx,
+                    'from_import': None,
                     'dependency_type': 'output',
                     'is_parameter_modifying_task': False,
                 })
@@ -388,6 +407,7 @@ def get_input_dependency(task_info_lst, input_dict, input_task_idx):
             ):
                 input_dependency.append({
                     'from_task': task_idx,
+                    'from_import': None,
                     'dependency_type': 'input',
                     'is_parameter_modifying_task': False,
                 })
@@ -403,7 +423,7 @@ def get_input_dependency(task_info_lst, input_dict, input_task_idx):
     return input_dependency
 
 
-def get_dependency_idx(task_info_lst):
+def get_dependency_idx(task_info_lst, imported_parameters):
     """Find the dependencies between tasks.
 
     Parameters
@@ -413,6 +433,7 @@ def get_dependency_idx(task_info_lst):
             context : str
             schema : TaskSchema
             local_inputs : dict
+    imported_parameters : dict
 
     Returns
     -------
@@ -457,7 +478,12 @@ def get_dependency_idx(task_info_lst):
             input_context = input_dict['context']
             is_locally_defined = input_name in task_info['local_inputs']['inputs']
             default_defined = input_name in task_info['local_inputs']['default_inputs']
-            input_dependency = get_input_dependency(task_info_lst, input_dict, task_idx)
+            input_dependency = get_input_dependency(
+                task_info_lst,
+                input_dict,
+                task_idx,
+                imported_parameters,
+            )
 
             add_input_dep = False
             if is_locally_defined:
@@ -478,10 +504,11 @@ def get_dependency_idx(task_info_lst):
                 msg = (
                     f'Task input "{input_name}"{inp_cont_fmt} for task "{task_name}"'
                     f'{task_cont_fmt} appears to be missing. A value must be specified '
-                    f'locally, or a default value must be provided in the schema, or an '
+                    f'locally, a default value must be provided in the schema, an '
                     f'additional task should be added to the workflow that generates the '
-                    f'parameter. If such a task already exists, try reordering the tasks '
-                    f'in the order in which would you expect them to run.'
+                    f'parameter, or the parameter must be imported from an existing '
+                    f'workflow. If a suitable task already exists, try reordering the '
+                    f'tasks in the order in which would you expect them to run.'
                 )
                 raise TaskParameterError(msg)
 
@@ -551,8 +578,14 @@ def singularise_input_dependencies(dep_idx_multi):
         # Add task dependencies to each task:
         for dep_idx in dep_idx_pathway_i:
             dep_idx['task_dependencies'] = list(set([
-                p_val['from_task'] for p_val in dep_idx['parameter_dependencies'].values()
+                p_val['from_task']
+                for p_val in dep_idx['parameter_dependencies'].values()
+                if p_val['from_task'] is not None
             ]))
+            dep_idx['has_imports'] = any([
+                p_val['from_import']
+                for p_val in dep_idx['parameter_dependencies'].values()
+            ])
 
         try:
             check_direct_circular_dependencies(dep_idx_pathway_i)
@@ -936,7 +969,7 @@ def validate_task_dict(task, is_from_file, all_software, all_task_schemas,
     return task_list
 
 
-def order_tasks(task_lst):
+def order_tasks(task_lst, imported_parameters):
     """Order tasks according to their dependencies.
 
     Parameters
@@ -947,6 +980,7 @@ def order_tasks(task_lst):
             context : str
             schema : TaskSchema
             output_map_options
+    imported_parameters : dict
 
     Returns
     -------
@@ -964,7 +998,7 @@ def order_tasks(task_lst):
         out_opts = i['schema'].validate_output_map_options(i['output_map_options'])
         task_lst[i_idx]['output_map_options'] = out_opts
 
-    dep_idx = get_dependency_idx(task_lst)
+    dep_idx = get_dependency_idx(task_lst, imported_parameters)
     dep_idx_singled = singularise_input_dependencies(dep_idx)
 
     sort_idx = [i['original_idx'] for i in dep_idx_singled]
@@ -1045,14 +1079,9 @@ def resolve_group(group, local_inputs, repeats_idx):
     return group_resolved
 
 
-def get_input_groups(task_idx, task_lst, dependency_idx, element_idx):
-    """Get the (local inputs) group dict for each non-local input of a task.
-
-    Parameters
-    ----------
-    non_local_inputs : list of dict
-
-    """
+def get_input_groups(task_idx, task_lst, dependency_idx, element_idx,
+                     imported_parameters):
+    """Get the (local inputs) group dict for each non-local input of a task."""
 
     task = task_lst[task_idx]
     local_input_names = list(task['local_inputs']['inputs'].keys())
@@ -1064,18 +1093,31 @@ def get_input_groups(task_idx, task_lst, dependency_idx, element_idx):
 
         input_alias = non_local_input_i['alias']
         input_name = non_local_input_i['name']
+        input_context = non_local_input_i['context']
+
         group_name = task['schema'].get_input_by_alias(input_alias)['group']
-
-        task_param_deps = dependency_idx[task_idx]['parameter_dependencies']
-        input_task_idx = task_param_deps[input_alias]['from_task']
-        input_task = task_lst[input_task_idx]
-
         if group_name == 'default':
             group_name_ = group_name
         else:
             group_name_ = 'user_group_' + group_name
 
-        group_dict = element_idx[input_task_idx]['groups']
+        task_param_deps = dependency_idx[task_idx]['parameter_dependencies']
+
+        input_task_idx = None
+        input_task_name = None
+        import_key = None
+
+        if task_param_deps[input_alias]['from_task'] is not None:
+            # Parameter is from another task in this workflow.
+            input_task_idx = task_param_deps[input_alias]['from_task']
+            input_task = task_lst[input_task_idx]
+            input_task_name = input_task['name']
+            group_dict = element_idx[input_task_idx]['groups']
+        else:
+            # Parameter is imported from another workflow.
+            import_key = (input_name, input_context or DEFAULT_TASK_CONTEXT)
+            group_dict = imported_parameters[import_key]['groups']
+
         group_names_fmt = ', '.join([f'"{i}"' for i in group_dict.keys()])
         group_dat = group_dict.get(group_name_)
 
@@ -1090,14 +1132,15 @@ def get_input_groups(task_idx, task_lst, dependency_idx, element_idx):
                 **group_dat,
                 'group_name': group_name,
                 'task_idx': input_task_idx,
-                'task_name': input_task['name'],
+                'task_name': input_task_name,
+                'import_key': import_key,
             }
         })
 
     return input_groups
 
 
-def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
+def get_element_idx(task_lst, dep_idx, num_iterations, iterate, imported_parameters):
     """For each task, find the element indices that determine the elements to be used
     (i.e from upstream tasks) to populate task inputs.
 
@@ -1143,8 +1186,8 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
         loc_in = downstream_task['local_inputs']
         schema = downstream_task['schema']
 
-        if not upstream_tasks:
-            # This task does not depend on any other tasks.
+        if not upstream_tasks and not dep_idx[idx]['has_imports']:
+            # This task does not depend on any other tasks or imports.
             groups = {}
             for group_name, group in loc_in['groups'].items():
                 group = resolve_group(group, loc_in['inputs'], loc_in['repeats_idx'])
@@ -1170,8 +1213,14 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
             }
 
         else:
-            # This task depends on other tasks.
-            input_groups = get_input_groups(idx, task_lst, dep_idx, element_idx)
+            # This task depends on other tasks and/or imported parameters.
+            input_groups = get_input_groups(
+                idx,
+                task_lst,
+                dep_idx,
+                element_idx,
+                imported_parameters,
+            )
             is_nesting_mixed = len(set([i['nest'] for i in input_groups.values()])) > 1
 
             for input_alias, group_info in input_groups.items():
@@ -1230,6 +1279,7 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
                                     'task_idx': [None] * len(input_idx),
                                     'element_idx': [None] * len(input_idx),
                                     'group': [None] * len(input_idx),
+                                    'import_key': [None] * len(input_idx),
                                 }
                             })
 
@@ -1243,6 +1293,7 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
                                 'task_idx': [in_group['task_idx']] * len(element_idx_i),
                                 'element_idx': element_idx_i,
                                 'group': [in_group['group_name']] * len(element_idx_i),
+                                'import_key': [in_group['import_key']] * len(element_idx_i),
                             }
                         })
 
@@ -1271,6 +1322,7 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
                             'task_idx': [in_group['task_idx']] * len(element_idx_i),
                             'group': [in_group['group_name']] * len(element_idx_i),
                             'element_idx': element_idx_i,
+                            'import_key': [in_group['import_key']] * len(element_idx_i),
                         }
                     })
 
@@ -1314,6 +1366,7 @@ def get_element_idx(task_lst, dep_idx, num_iterations, iterate):
                             'task_idx': [in_group['task_idx']] * len(element_idx_i),
                             'group': [in_group['group_name']] * len(element_idx_i),
                             'element_idx': element_idx_i,
+                            'import_key': [in_group['import_key']] * len(element_idx_i),
                         }
                     })
 
@@ -1574,7 +1627,8 @@ def validate_inputs(task_lst):
         schema.check_surplus_inputs(defined_inputs)
 
 
-def init_tasks(workflow, task_lst, is_from_file, check_integrity=True):
+def init_tasks(workflow, task_lst, imported_parameters, is_from_file,
+               check_integrity=True):
     """Construct and validate Task objects and the element indices
     from which to populate task inputs.
 
@@ -1584,6 +1638,16 @@ def init_tasks(workflow, task_lst, is_from_file, check_integrity=True):
         List of task definitions. Each task dict can have the following
         keys:
             name
+    imported_parameters : dict
+        Dict whose keys are parameter names that have been imported from another workflow
+        and whose values are dicts containing information about the imported data, with
+        keys:
+            data_idx : list of int
+                Indices of the parameter values in the HDF5 /element_idx group.
+            iteration_idx : list of int
+            groups : dict
+            original_name: : str
+            context : str
     is_from_file : bool
         If True, assume we are loading tasks from an HDF5 file, otherwise,
         the tasks are being constructed from an entirely new Workflow.
@@ -1620,7 +1684,7 @@ def init_tasks(workflow, task_lst, is_from_file, check_integrity=True):
     task_lst = init_local_inputs(task_lst, is_from_file, check_integrity=False)
 
     # Get dependencies, sort and add `task_idx` to each task:
-    task_lst, dep_idx = order_tasks(task_lst)
+    task_lst, dep_idx = order_tasks(task_lst, imported_parameters)
 
     validate_inputs(task_lst)
 

--- a/matflow/models/construction.py
+++ b/matflow/models/construction.py
@@ -507,8 +507,9 @@ def get_dependency_idx(task_info_lst, imported_parameters):
                     f'locally, a default value must be provided in the schema, an '
                     f'additional task should be added to the workflow that generates the '
                     f'parameter, or the parameter must be imported from an existing '
-                    f'workflow. If a suitable task already exists, try reordering the '
-                    f'tasks in the order in which would you expect them to run.'
+                    f'workflow (with the correct context set). If a suitable task already'
+                    f' exists, try reordering the tasks in the order in which would you '
+                    f'expect them to run.'
                 )
                 raise TaskParameterError(msg)
 

--- a/matflow/models/task.py
+++ b/matflow/models/task.py
@@ -930,6 +930,10 @@ class Task(object):
         """Get the HDF5 path to this task."""
         return self.workflow.HDF5_path + f'/\'tasks\'/data/data_{self.task_idx}'
 
+    @property
+    def elements_idx(self):
+        return self.workflow.elements_idx[self.task_idx]
+
     def get_elements_from_iteration(self, iteration_idx):
         """Get a list of Element objects corresponding to a given iteration index.
 
@@ -943,8 +947,7 @@ class Task(object):
 
         """
 
-        elems_idx = self.workflow.elements_idx[self.task_idx]
-        all_elems_iter_idx = elems_idx['iteration_idx']
+        all_elems_iter_idx = self.elements_idx['iteration_idx']
         max_iter_idx = max(all_elems_iter_idx)
 
         iteration_idx_original = iteration_idx

--- a/matflow/models/task.py
+++ b/matflow/models/task.py
@@ -555,7 +555,10 @@ class TaskTuple(object):
         for task in self._task_tuple:
             if task.unique_name == task_unique_name:
                 return task
-        raise AttributeError
+        task_list_fmt = ', '.join([f'"{i.unique_name}"' for i in self._task_tuple])
+        msg = (f'Task "{task_unique_name}" does not exist. Available tasks are: '
+               f'{task_list_fmt}.')
+        raise AttributeError(msg)
 
     def __dir__(self):
         return super().__dir__() + [i.unique_name for i in self._task_tuple]

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -119,7 +119,7 @@ class Workflow(object):
                          ] if figures else []
         self._metadata = metadata or {}
 
-        self._import_list = self._validate_import_list(import_list)
+        self._import_list = self._validate_import_list(import_list, self.is_from_file)
         tasks, task_elements, dep_idx = init_tasks(
             self,
             tasks,
@@ -254,7 +254,7 @@ class Workflow(object):
                 for k, v in attributes.items():
                     handle[path].attrs[k] = v
 
-    def _validate_import_list(self, import_list):
+    def _validate_import_list(self, import_list, is_from_file):
 
         if not import_list:
             return import_list
@@ -305,14 +305,15 @@ class Workflow(object):
                 from_bad_keys_fmt = ', '.join([f'"{i}"' for i in from_bad_keys])
                 raise ValueError(msg + f'Unknown keys are: {from_bad_keys_fmt}.')
 
-            # Check workflow is a file:
-            workflow_path = Path(import_item['from']['workflow']).resolve()
-            if not workflow_path.is_file():
-                msg = (f'The workflow path specified in import item {idx} of '
-                       f'`import_list` is not a file: "{workflow_path}".')
-                raise ValueError(msg)
+            if not is_from_file:
+                # Check workflow is a file:
+                workflow_path = Path(import_item['from']['workflow']).resolve()
+                if not workflow_path.is_file():
+                    msg = (f'The workflow path specified in import item {idx} of '
+                           f'`import_list` is not a file: "{workflow_path}".')
+                    raise ValueError(msg)
 
-            import_item['from']['workflow'] = str(workflow_path)
+                import_item['from']['workflow'] = str(workflow_path)
 
         return import_list
 

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -2094,23 +2094,53 @@ class Workflow(object):
                 tasks_info.append(task_dict)
         return tasks_info
 
-    def get_input_tasks(self, parameter_name):
-        'Return task indices of tasks in which a given parameter is an input.'
+    def get_input_tasks(self, parameter_name, context=None):
+        """Return task indices of tasks in which a given parameter is an input.
+
+        Parameters
+        ----------
+        parameter_name : str
+            Name of the parameter to locate.
+        context : str, optional
+            If specified, limit the search to only tasks with the given context.
+
+        Returns
+        -------
+        input_task_idx : list of int
+            List of task indices in which the specified parameter features as an input.
+
+        """
 
         input_task_idx = []
         for task in self.tasks:
             if parameter_name in task.schema.input_names:
-                input_task_idx.append(task.task_idx)
+                if (context is not None and task.context == context) or context is None:
+                    input_task_idx.append(task.task_idx)
 
         return input_task_idx
 
-    def get_output_tasks(self, parameter_name):
-        'Return task indices of tasks in which a given parameter is an output.'
+    def get_output_tasks(self, parameter_name, context=None):
+        """Return task indices of tasks in which a given parameter is an output.
+
+        Parameters
+        ----------
+        parameter_name : str
+            Name of the parameter to locate.
+        context : str, optional
+            If specified, limit the search to only tasks with the given context.
+
+        Returns
+        -------
+        output_task_idx : list of int
+            List of task indices in which the specified parameter features as an output.
+
+        """
 
         output_task_idx = []
         for task in self.tasks:
             if parameter_name in task.schema.outputs:
-                output_task_idx.append(task.task_idx)
+                if (context is not None and task.context == context) or context is None:
+                    output_task_idx.append(task.task_idx)
 
         return output_task_idx
 

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -333,9 +333,14 @@ class Workflow(object):
                 # Check workflow is a file:
                 workflow_path = Path(import_item['from']['workflow']).resolve()
                 if not workflow_path.is_file():
-                    msg = (f'The workflow path specified in import item {idx} of '
-                           f'`import_list` is not a file: "{workflow_path}".')
-                    raise ValueError(msg)
+                    trial_workflow_path = workflow_path / 'workflow.hdf5'
+                    if not trial_workflow_path.is_file():
+                        msg = (f'The workflow path specified in import item {idx} of '
+                               f'`import_list` is not a file (nor is this path joined '
+                               f'with "workflow.hdf5"): "{workflow_path}".')
+                        raise ValueError(msg)
+                    else:
+                        workflow_path = trial_workflow_path
 
                 import_item['from']['workflow'] = str(workflow_path)
 

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -435,7 +435,7 @@ class Workflow(object):
 
             # Element data are zero padded and include name of parameter for convenience,
             # so map their integer index to the actual group names:
-            idx_map = {int(re.search('(\d+)', i).group()): i for i in handle[path]}
+            idx_map = {int(re.search(r'(\d+)', i).group()): i for i in handle[path]}
 
             out = []
             for i in idx:

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -163,6 +163,7 @@ class Workflow(object):
                 'local_inputs': i.local_inputs,
                 'name': i.name,
                 'schema': i.schema,
+                'context': i.context,
             } for i in tasks
         ]
         elements_idx = get_element_idx(

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -1107,12 +1107,6 @@ class Workflow(object):
             config_dir=Config.get('hpcflow_config_dir'),
         )
 
-    def get_extended_workflows(self):
-        if self.extend_paths:
-            return [Workflow.load(i, full_path=True) for i in self.extend_paths]
-        else:
-            return None
-
     def as_dict(self):
         """Return attributes dict with preceding underscores removed."""
         out = {k.lstrip('_'): getattr(self, k) for k in self.__slots__}

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -34,7 +34,7 @@ from matflow.hicklable import to_hicklable
 from matflow.models.command import DEFAULT_FORMATTERS
 from matflow.models.construction import init_tasks, get_element_idx
 from matflow.models.software import SoftwareInstance
-from matflow.models.task import TaskStatus, DEFAULT_TASK_CONTEXT
+from matflow.models.task import TaskStatus, DEFAULT_TASK_CONTEXT, Task
 from matflow.models.parameters import Parameters
 from matflow.utils import (
     parse_times,
@@ -318,6 +318,10 @@ class Workflow(object):
                        f'a dict, but it is not.')
                 raise ValueError(msg)
 
+            new_context = import_item.get('context')
+            if new_context:
+                import_item['context'] = Task.make_safe_context(new_context)
+
             from_item_keys = set(import_item['from'])
             from_miss_keys = from_req_keys - from_item_keys
             from_bad_keys = from_item_keys - from_good_keys
@@ -329,6 +333,10 @@ class Workflow(object):
             if from_bad_keys:
                 from_bad_keys_fmt = ', '.join([f'"{i}"' for i in from_bad_keys])
                 raise ValueError(msg + f'Unknown keys are: {from_bad_keys_fmt}.')
+
+            from_context = import_item['from'].get('context')
+            if from_context:
+                import_item['from']['context'] = Task.make_safe_context(from_context)
 
             if not is_from_file:
                 # Check workflow is a file:
@@ -571,7 +579,7 @@ class Workflow(object):
         if not new_parameter_name:
             new_parameter_name = parameter_name
 
-        if not new_context:
+        if new_context is None:
             new_context = context or DEFAULT_TASK_CONTEXT
 
         imp_workflow = Workflow.load_HDF5_file(workflow_path, full_path=True)

--- a/matflow/models/workflow.py
+++ b/matflow/models/workflow.py
@@ -647,7 +647,13 @@ class Workflow(object):
             'iteration_idx': [],    # populated below
         }
         for element in element_objs:
-            data = element.get_output(parameter_name)
+            try:
+                data = element.get_output(parameter_name)
+            except (KeyError, AttributeError):
+                msg = (f'The output parameter "{parameter_name}" from element '
+                       f'{element.element_idx} of task "{imp_task.unique_name}" could '
+                       f'not be found in the workflow at "{workflow_path}".')
+                raise ParameterImportError(msg)
             imported_data_dict['data'].append(data)
             imported_data_dict['iteration_idx'].append(iteration_idx)
 

--- a/matflow/profile.py
+++ b/matflow/profile.py
@@ -22,6 +22,8 @@ def parse_workflow_profile(profile_path):
         'metadata',
         'num_iterations',
         'iterate',
+        'import',
+        'import_list',  # equivalent to 'import'; provides a Python-code-safe variant.
     ]
 
     miss_keys = list(set(req_keys) - set(profile.keys()))
@@ -33,6 +35,10 @@ def parse_workflow_profile(profile_path):
     if bad_keys:
         bad_keys_fmt = ', '.join([f'"{i}"' for i in bad_keys])
         raise ProfileError(f'Unknown keys in profile: {bad_keys_fmt}.')
+
+    if 'import' in profile and 'import_list' in profile:
+        raise ProfileError(f'Specify exactly one of `import` and `import_list`. '
+                           f'These options are functionally equivalent.')
 
     for i in task_globals:
         if i in profile:
@@ -51,6 +57,7 @@ def parse_workflow_profile(profile_path):
         'extends': profile.get('extends'),
         'archive': profile.get('archive'),
         'archive_excludes': profile.get('archive_excludes'),
+        'import_list': profile.get('import') or profile.get('import_list'),
     }
 
     return workflow_dict


### PR DESCRIPTION
Add ability to import parameters from existing workflows, fixing #30.

Tasks:
- [x] Formalise workflow options to import data from another workflow.
- [x] Implement importation of workflow data, saving in /element_data on workflow-make, and referencing in `Workflow.imported_parameters`
- [x] Initial implementation
- [x] Check/fix usage when specifying "non-safe" context (both import context and new context)
- [x] Check/document (via exception) usage when selecting a subset of elements, especially when using a custom group
- [x] Check importing from a multi-iteration workflow